### PR TITLE
feat: access token  protected route#42

### DIFF
--- a/frontend/middleware.ts
+++ b/frontend/middleware.ts
@@ -1,0 +1,20 @@
+// middleware.ts
+import { NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+
+export default function middleware(req: NextRequest) {
+  const token = req.cookies["access_token"];
+  const { pathname } = req.nextUrl;
+
+  if (pathname.includes("/login")) {
+    return NextResponse.next();
+  }
+
+  // 토큰이 없으면 로그인 페이지로 리디렉트
+  if (!token) {
+    return NextResponse.redirect(new URL("/login", req.url));
+  }
+
+  // 토큰이 있으면 요청을 계속 진행
+  return NextResponse.next();
+}

--- a/frontend/src/api/axios/axios.instance.ts
+++ b/frontend/src/api/axios/axios.instance.ts
@@ -1,4 +1,5 @@
 import axios from "axios";
+import Router from "next/router";
 import { getCookie, removeCookie } from "@/api/cookie/cookies";
 import {
   STATUS_401_UNAUTHORIZED,
@@ -24,13 +25,13 @@ instance.interceptors.response.use(
     return response;
   },
   (error) => {
+    console.log("error", error);
     if (error.response?.status === STATUS_401_UNAUTHORIZED) {
       removeCookie("access_token", {
         path: "/",
         domain: `${process.env.FE_DOMAIN}`,
       });
-      window.location.href = "/login";
-      alert(error.response.data.message);
+      Router.push("/login"); // SPA 방식 리디렉션
     }
     return Promise.reject(error);
   },

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -4,6 +4,7 @@ import "@/ui/css/globals.css";
 import RecoilRootProvider from "@/recoil/recoilRootProvider";
 import SocketProvider from "@/components/SocketProvider";
 import StyledComponentsRegistry from "@/lib/registry";
+import ProtectedRouted from "@/components/ProtectedRoute";
 
 const inter = Inter({ subsets: ["latin"] });
 
@@ -26,7 +27,9 @@ export default function RootLayout({
       <body className={`${inter.className} antialiased`}>
         <SocketProvider>
           <RecoilRootProvider>
-            <StyledComponentsRegistry>{children}</StyledComponentsRegistry>
+            <StyledComponentsRegistry>
+              <ProtectedRouted>{children}</ProtectedRouted>
+            </StyledComponentsRegistry>
           </RecoilRootProvider>
         </SocketProvider>
         <div id="modal-portal"></div>

--- a/frontend/src/components/ProtectedRoute.tsx
+++ b/frontend/src/components/ProtectedRoute.tsx
@@ -1,0 +1,22 @@
+"use client";
+import { useEffect } from "react";
+import { useRouter, usePathname } from "next/navigation";
+import { getCookie } from "@/api/cookie/cookies";
+
+export default function ProtectedRoute({ children }) {
+  const token = getCookie("access_token");
+  const router = useRouter();
+  const pathname = usePathname();
+
+  useEffect(() => {
+    if (pathname !== "/login" && !token) {
+      router.replace("/login");
+    }
+  }, [router, token]);
+
+  if (!token && pathname !== "/login") {
+    return <div></div>;
+  }
+
+  return children;
+}


### PR DESCRIPTION
## Next.js의 Router
클라이언트 사이드 네비게이션: Router를 사용하는 네비게이션은 클라이언트 사이드에서 이루어지며, 이는 페이지의 전체 리로드 없이 URL을 변경할 수 있습니다. 이 방식은 Single Page Application(SPA)의 특징을 유지하면서 빠른 페이지 전환을 가능하게 합니다.

동적 라우팅 지원: Next.js는 파일 기반 라우팅을 사용하며, Router 객체를 통해 동적 라우트 파라미터를 처리할 수 있습니다. 예를 들어, URL의 일부분을 변수로 사용하여 페이지 컴포넌트에 전달할 수 있습니다.

프로그래매틱 네비게이션: Router.push나 Router.replace 같은 메소드를 사용하여 프로그래매틱하게 라우팅을 제어할 수 있습니다. 이를 통해 사용자의 행동에 따라 동적으로 라우트를 변경할 수 있습니다.

Next.js 생태계와의 통합: Router는 Next.js의 기능과 밀접하게 통합되어 있으며, 서버 사이드 렌더링(SSR)과 정적 사이트 생성(SSG)에서의 라우팅 처리와도 잘 호환됩니다.

## 브라우저의 window.location
전체 페이지 리로드: window.location을 변경하면 브라우저가 새 URL로 페이지를 완전히 리로드합니다. 이는 SPA의 빠른 페이지 전환과는 대조적으로, 더 전통적인 웹 페이지의 네비게이션 방식입니다.

간단한 URL 관리: window.location 객체를 사용하여 현재 URL을 읽거나, 새 URL로 이동할 수 있습니다. 이 방식은 SPA의 복잡한 라우팅 요구 사항을 다루는 데는 적합하지 않을 수 있습니다.

제한적 프로그래매틱 네비게이션: window.location.href를 설정하거나 window.location.replace를 사용하여 현재 페이지를 새 URL로 바꿀 수 있습니다. 그러나 이 방법은 현재 페이지 상태를 유지하지 못하고 전체 페이지를 새로고침합니다.

범용성: window.location은 모든 웹 환경에서 사용할 수 있는 표준 브라우저 API입니다. 어떤 프레임워크나 라이브러리와도 독립적으로 작동합니다.

